### PR TITLE
Fix typo in input vars for yq3 script

### DIFF
--- a/scripts/setup-yq3.sh
+++ b/scripts/setup-yq3.sh
@@ -3,7 +3,7 @@
 SCRIPT_DIR=$(cd $(dirname "$0"); pwd -P)
 
 DEST_DIR="$1"
-TYPE="$1"
+TYPE="$2"
 ARCH="$3"
 
 if [[ "$TYPE" == "macos" ]]; then


### PR DESCRIPTION
correct typo in input args to `setup-yq3.sh` - fixes #79 

Signed-off-by: Tim Robinson <timroster@gmail.com>