### PR TITLE
Add logic for BIN_DIR in setup-existing

### DIFF
--- a/scripts/setup-existing.sh
+++ b/scripts/setup-existing.sh
@@ -10,6 +10,10 @@ function debug() {
   echo "${SCRIPT_DIR}: (${CLI_NAME}) $1" >> clis-debug.log
 }
 
+mkdir -p "${DEST_DIR}"
+
+BIN_DIR=$(cd "${DEST_DIR}"; pwd -P)
+
 if command -v "${BIN_DIR}/${CLI_NAME}" 1> /dev/null 2> /dev/null; then
   debug "CLI already provided in bin_dir"
   exit 0


### PR DESCRIPTION
New `setup-existing.sh` script references `${BIN_DIR}` variable that is empty producing errors like:

```
│ Error Message: ln: /jq: Permission denied
```

Copies code from `setup-binary.sh` to check/create directory and set `${BIN_DIR}` before first use.

Signed-off-by: Tim Robinson <timroster@gmail.com>