### PR TITLE
Pass and use arch in setup-gitu

### DIFF
--- a/scripts/setup-binaries.sh
+++ b/scripts/setup-binaries.sh
@@ -108,7 +108,7 @@ if [[ "${CLIS}" =~ ibmcloud-cr ]]; then
 fi
 
 if [[ "${CLIS}" =~ gitu ]]; then
-  "${SCRIPT_DIR}/setup-gitu.sh" "${DEST_DIR}" "${TYPE}" || exit 1
+  "${SCRIPT_DIR}/setup-gitu.sh" "${DEST_DIR}" "${TYPE}" "${ARCH}" || exit 1
 fi
 
 if [[ "${CLIS}" =~ openshift-install ]]; then

--- a/scripts/setup-gitu.sh
+++ b/scripts/setup-gitu.sh
@@ -21,4 +21,9 @@ if [[ -z "${RELEASE}" ]]; then
   exit 1
 fi
 
+# Work around different suffix for gitu release
+if [[ "${ARCH}" == "amd64" ]]; then
+  ARCH="x64"
+fi
+
 "${SCRIPT_DIR}/setup-binary.sh" "${DEST_DIR}" "${CLI_NAME}" "https://github.com/cloud-native-toolkit/git-client/releases/download/${RELEASE}/gitu-${TYPE}-${ARCH}" --version

--- a/scripts/setup-gitu.sh
+++ b/scripts/setup-gitu.sh
@@ -4,7 +4,7 @@ SCRIPT_DIR=$(cd $(dirname "$0"); pwd -P)
 
 DEST_DIR="$1"
 TYPE="$2"
-ARCH="x64"
+ARCH="$3"
 
 CLI_NAME="gitu"
 


### PR DESCRIPTION
updates `setup-binaries.sh` to send arch as argument, removes hard coded arch in `setup-gitu` as there are now releases for x64 and arm64. Fixes #82 

Signed-off-by: Tim Robinson <timroster@gmail.com>