### PR TITLE
Add arch logic for igc

### DIFF
--- a/scripts/setup-igc.sh
+++ b/scripts/setup-igc.sh
@@ -20,7 +20,7 @@ if [[ -z "${RELEASE}" ]]; then
   exit 1
 fi
 
-if [[ "${ARCH}" == "amd64"]]; then
+if [[ "${ARCH}" == "amd64" ]]; then
   "${SCRIPT_DIR}/setup-binary.sh" "${DEST_DIR}" "${CLI_NAME}" "https://github.com/cloud-native-toolkit/ibm-garage-cloud-cli/releases/download/${RELEASE}/igc-${TYPE}" --version
 else
   "${SCRIPT_DIR}/setup-binary.sh" "${DEST_DIR}" "${CLI_NAME}" "https://github.com/cloud-native-toolkit/ibm-garage-cloud-cli/releases/download/${RELEASE}/igc-${TYPE}-${ARCH}" --version

--- a/scripts/setup-igc.sh
+++ b/scripts/setup-igc.sh
@@ -4,6 +4,7 @@ SCRIPT_DIR=$(cd $(dirname "$0"); pwd -P)
 
 DEST_DIR="$1"
 TYPE="$2"
+ARCH="$3"
 CLI_NAME="igc"
 
 export PATH="${DEST_DIR}:${PATH}"
@@ -19,4 +20,8 @@ if [[ -z "${RELEASE}" ]]; then
   exit 1
 fi
 
-"${SCRIPT_DIR}/setup-binary.sh" "${DEST_DIR}" "${CLI_NAME}" "https://github.com/cloud-native-toolkit/ibm-garage-cloud-cli/releases/download/${RELEASE}/igc-${TYPE}" --version
+if [[ "${ARCH}" == "amd64"]]; then
+  "${SCRIPT_DIR}/setup-binary.sh" "${DEST_DIR}" "${CLI_NAME}" "https://github.com/cloud-native-toolkit/ibm-garage-cloud-cli/releases/download/${RELEASE}/igc-${TYPE}" --version
+else
+  "${SCRIPT_DIR}/setup-binary.sh" "${DEST_DIR}" "${CLI_NAME}" "https://github.com/cloud-native-toolkit/ibm-garage-cloud-cli/releases/download/${RELEASE}/igc-${TYPE}-${ARCH}" --version
+fi


### PR DESCRIPTION
updates `scripts/setup-igc.sh` to append `arm64` to url for download URL for igc, does not append `${ARCH}` for `amd64` as the current igc releases are appended with `x64`

fixes #91 

Signed-off-by: Tim Robinson <timroster@gmail.com>