### PR TITLE
fix(mac): use yq3 amd64 binary on macos arm64 arch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ test/stages/module
 terraform.tfvars
 aws.code-workspace
 .vscode
+bin2
+.bin_dir
+clis-debug.log

--- a/scripts/setup-binaries.sh
+++ b/scripts/setup-binaries.sh
@@ -50,7 +50,12 @@ mkdir -p "${DEST_DIR}" || exit 1
 "${SCRIPT_DIR}/setup-oc.sh" "${DEST_DIR}" "${TYPE}" "${ARCH}" || exit 1
 
 if [[ "${CLIS}" =~ yq ]]; then
-  "${SCRIPT_DIR}/setup-yq3.sh" "${DEST_DIR}" "${TYPE}" "${ARCH}" || exit 1
+  if [[ "${TYPE}" == "macos" ]] && [[ "${ARCH}" == "arm64" ]]; then
+    # there is no Mac arm64 for yq3, use the amd64 instead
+    "${SCRIPT_DIR}/setup-yq3.sh" "${DEST_DIR}" "${TYPE}" amd64 || exit 1
+  else
+    "${SCRIPT_DIR}/setup-yq3.sh" "${DEST_DIR}" "${TYPE}" "${ARCH}" || exit 1
+  fi
   "${SCRIPT_DIR}/setup-yq4.sh" "${DEST_DIR}" "${TYPE}" "${ARCH}" || exit 1
 fi
 


### PR DESCRIPTION
yq3 does not have macos arm64 binary. as macos is also supporting amd64 arch, use the amd64 arch yq3 binary.